### PR TITLE
chore: upgrade to Go 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.25 as build
+FROM golang:1.26 as build
 ARG IBM_DB_VER=v0.4.4
 
 RUN go install github.com/ibmdb/go_ibm_db/installer@${IBM_DB_VER}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/ibm-db2-prometheus-exporter
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
Bumps the Go toolchain to the current latest release.

- `go.mod`: `go 1.25.0` → `go 1.26.5`
- `Dockerfile`: `golang:1.25` → `golang:1.26`

CI picks the version up automatically via `go-version-file: 'go.mod'`.

Not verified locally: the sources are `//go:build !arm64`, so there are no buildable packages on darwin/arm64, and a `GOOS=linux GOARCH=amd64` cross-build fails inside `go_ibm_db/api` with cgo off (pre-existing, unrelated to this bump). Relies on CI / the Docker build for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)